### PR TITLE
Make exceptions.py documentation more generic

### DIFF
--- a/opnieuw/exceptions.py
+++ b/opnieuw/exceptions.py
@@ -8,8 +8,4 @@ class RetryException(Exception):
     """
     Defines a custom RetryException that can be raised for specific errors we
     want to retry on.
-
-    E.g.: Cdiscount can return an `UnexpectedException` containing little info,
-    but is usually automatically resolved on a retry. We raise this Exception
-    which is also defined as a server failure below.
     """


### PR DESCRIPTION
I think this comment was inherited from a specific use case in Channable, which is not much use to other users.