### PR TITLE
added support for max_calls_total=1

### DIFF
--- a/opnieuw/retries.py
+++ b/opnieuw/retries.py
@@ -65,7 +65,7 @@ def calculate_exponential_multiplier(
     """
 
     count = 2 ** (max_calls_total - 1) - 1
-    multiplier = retry_window_after_first_call_in_seconds / count
+    multiplier = retry_window_after_first_call_in_seconds / max(count, 1)
 
     return multiplier
 

--- a/tests/test_exponential_multiplier.py
+++ b/tests/test_exponential_multiplier.py
@@ -10,6 +10,15 @@ from opnieuw.retries import calculate_exponential_multiplier
 
 class ExponentialMultiplierTests(unittest.TestCase):
     def test_calculate_exponential_multiplier(self):
+        # test for max_calls_total=1 and 2
+        expected_multiplier = 120.0
+        multiplier = calculate_exponential_multiplier(1, 120)
+        self.assertEqual(multiplier, expected_multiplier)
+
+        multiplier = calculate_exponential_multiplier(2, 120)
+        self.assertEqual(multiplier, expected_multiplier)
+
+        # test max_calls_total > 2
         expected_multiplier = 8.0
         multiplier = calculate_exponential_multiplier(5, 120)
 


### PR DESCRIPTION
# Problem
If Opnieuw is called with parameter **max_calls_total=1**, the following exception will occur:

```
Traceback (most recent call last):
  File "scratch.py", line 8, in <module>
    print(1, calculate_exponential_multiplier(1, 1))
  File "opnieuw/retries.py", line 68, in calculate_exponential_multiplier
    multiplier = retry_window_after_first_call_in_seconds / count
ZeroDivisionError: division by zero
```

# Why would I like to be able to set max_calls_total to 1?
In development environments it is sometimes useful not to repeat the call in case of an error. Setting max_calls_total to 1 allows us to do this.