### PR TITLE
Add py.typed file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,9 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/channable/opnieuw",
     packages=setuptools.find_packages(),
+    package_data={
+        'opnieuw': ['py.typed'],
+    },
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: BSD License",


### PR DESCRIPTION
With this change we indicate opnieuw is able
to expose type information for all its objects.