### PR TITLE
Add switch to disable waiting for tests

### DIFF
--- a/opnieuw/retries.py
+++ b/opnieuw/retries.py
@@ -152,12 +152,15 @@ def retry(
     """
     Retry a function using a Full Jitter exponential backoff.
 
-    This function exposes two settings:
+    This function exposes four settings:
 
+     - `retry_on_exceptions` - A tuple of exception types to retry on.
      - `max_calls_total` - The maximum number of calls of the decorated
-       function, in total. Includes the inital call and all retries.
+       function, in total. Includes the initial call and all retries.
      - `retry_window_after_first_call_in_seconds` - The number of seconds to
        spread out the retries over after the first call.
+     - `namespace` - A name with which the wait behavior can be controlled
+       using the `opnieuw.test_util.retry_immediately` contextmanager.
 
     This function will:
 
@@ -199,7 +202,6 @@ def retry(
     Opnieuw is based on a retry algorithm off of:
         https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/
     """
-
     def decorator(f: F) -> F:
         @functools.wraps(f)
         def wrapper(*args: Any, **kwargs: Any) -> Any:
@@ -313,3 +315,6 @@ def retry_async(
         return cast(AF, wrapper)
 
     return decorator
+
+
+retry_async.__doc__ = retry.__doc__

--- a/opnieuw/retries.py
+++ b/opnieuw/retries.py
@@ -147,7 +147,7 @@ def retry(
     retry_on_exceptions: Union[Type[Exception], Tuple[Type[Exception], ...]],
     max_calls_total: int = 3,
     retry_window_after_first_call_in_seconds: int = 60,
-    namespace: str = None,
+    namespace: Optional[str] = None,
 ) -> Callable[[F], F]:
     """
     Retry a function using a Full Jitter exponential backoff.
@@ -263,7 +263,7 @@ def retry_async(
     retry_on_exceptions: Union[Type[Exception], Tuple[Type[Exception], ...]],
     max_calls_total: int = 3,
     retry_window_after_first_call_in_seconds: int = 60,
-    namespace: str = None,
+    namespace: Optional[str] = None,
 ) -> Callable[[AF], AF]:
     def decorator(f: AF) -> AF:
         @functools.wraps(f)

--- a/opnieuw/retries.py
+++ b/opnieuw/retries.py
@@ -67,10 +67,10 @@ def calculate_exponential_multiplier(
         ∴ 7m = 120 => m = 120 / 7
     """
 
-    count = 2 ** (max_calls_total - 1) - 1
+    count = 2.0 ** (max_calls_total - 1) - 1
     multiplier = retry_window_after_first_call_in_seconds / max(count, 1)
 
-    return cast(float, multiplier)
+    return multiplier
 
 
 class DoCall:

--- a/opnieuw/retries.py
+++ b/opnieuw/retries.py
@@ -70,7 +70,7 @@ def calculate_exponential_multiplier(
     count = 2 ** (max_calls_total - 1) - 1
     multiplier = retry_window_after_first_call_in_seconds / max(count, 1)
 
-    return multiplier
+    return cast(float, multiplier)
 
 
 class DoCall:

--- a/opnieuw/test_util.py
+++ b/opnieuw/test_util.py
@@ -12,8 +12,9 @@ class WaitLessRetryState(RetryState):
 
 @contextmanager
 def retry_immediately(namespace: Optional[str] = None) -> Iterator[None]:
+    old_state = __retry_state_namespaces[namespace]
     __retry_state_namespaces[namespace] = WaitLessRetryState
     try:
         yield
     finally:
-        __retry_state_namespaces[namespace] = RetryState
+        __retry_state_namespaces[namespace] = old_state

--- a/opnieuw/test_util.py
+++ b/opnieuw/test_util.py
@@ -4,7 +4,7 @@ from typing import Iterator, Optional
 from .retries import DoCall, RetryState, Action, __retry_state_namespaces
 
 
-class ManualRetryState(RetryState):
+class WaitLessRetryState(RetryState):
     def __iter__(self) -> Iterator[Action]:
         for _ in range(self.max_calls_total):
             yield DoCall()
@@ -12,7 +12,7 @@ class ManualRetryState(RetryState):
 
 @contextmanager
 def retry_immediately(namespace: Optional[str] = None) -> Iterator[None]:
-    __retry_state_namespaces[namespace] = ManualRetryState
+    __retry_state_namespaces[namespace] = WaitLessRetryState
     try:
         yield
     finally:

--- a/opnieuw/test_util.py
+++ b/opnieuw/test_util.py
@@ -1,0 +1,19 @@
+from contextlib import contextmanager
+from typing import Iterator, Optional
+
+from .retries import DoCall, RetryState, Action, __retry_state_namespaces
+
+
+class ManualRetryState(RetryState):
+    def __iter__(self) -> Iterator[Action]:
+        for _ in range(self.max_calls_total):
+            yield DoCall()
+
+
+@contextmanager
+def retry_immediately(namespace: Optional[str] = None) -> Iterator[None]:
+    __retry_state_namespaces[namespace] = ManualRetryState
+    try:
+        yield
+    finally:
+        __retry_state_namespaces[namespace] = RetryState

--- a/opnieuw/test_util.py
+++ b/opnieuw/test_util.py
@@ -12,6 +12,11 @@ class WaitLessRetryState(RetryState):
 
 @contextmanager
 def retry_immediately(namespace: Optional[str] = None) -> Iterator[None]:
+    """
+    Contextmanager that prevents waits between retries for all `retry` and
+    `retry_async` decorators with the provided namespace. None means all decorators
+    without a provided namespace will not wait.
+    """
     old_state = __retry_state_namespaces[namespace]
     __retry_state_namespaces[namespace] = WaitLessRetryState
     try:

--- a/tests/test_exponential_multiplier.py
+++ b/tests/test_exponential_multiplier.py
@@ -9,7 +9,7 @@ from opnieuw.retries import calculate_exponential_multiplier
 
 
 class ExponentialMultiplierTests(unittest.TestCase):
-    def test_calculate_exponential_multiplier(self):
+    def test_calculate_exponential_multiplier(self) -> None:
         # test for max_calls_total=1 and 2
         expected_multiplier = 120.0
         multiplier = calculate_exponential_multiplier(1, 120)

--- a/tests/test_opnieuw.py
+++ b/tests/test_opnieuw.py
@@ -12,7 +12,7 @@ from opnieuw.test_util import retry_immediately
 
 
 class TestRetryState(unittest.TestCase):
-    def test_never_stop(self):
+    def test_never_stop(self) -> None:
         retry_state = RetryState(
             MonotonicClock(),
             max_calls_total=0,
@@ -27,14 +27,14 @@ class TestRetryClock(unittest.TestCase):
     def setUp(self) -> None:
         self.clock = TestClock()
 
-    def test_negative_time_value(self):
+    def test_negative_time_value(self) -> None:
         try:
             self.clock.advance_to(-60.00)
-        except AssertionError as e:
+        except Exception as e:
             self.assertIsInstance(e, AssertionError)
             self.assertEqual(self.clock.time, 0.0)
 
-    def test_advanced_to(self):
+    def test_advanced_to(self) -> None:
         self.clock.advance_to(60.00)
         self.assertEqual(self.clock.time, 60.00)
 
@@ -54,31 +54,31 @@ class TestRetryDecorator(unittest.TestCase):
     def test_raise_exception(self) -> None:
         try:
             self.foo()
-        except TypeError as e:
+        except Exception as e:
             self.assertTrue(isinstance(e, TypeError))
 
-    def test_retry_times(self) -> None:
-        start = time.time()
+    def test_retry_with_waits(self) -> None:
+        start = time.monotonic()
         self.counter = 0
 
         try:
             self.foo()
         except TypeError as e:
-            end = time.time()
-            t_diff = end - start
-            self.assertGreater(t_diff, 0.5)
+            end = time.monotonic()
+            runtime_seconds = end - start
+            self.assertGreater(runtime_seconds, 0.5)
             self.assertEqual(self.counter, 3)
 
     def test_retry_immediately_global(self) -> None:
-        start = time.time()
+        start = time.monotonic()
         self.counter = 0
         with retry_immediately():
             try:
                 self.foo()
             except TypeError as e:
-                end = time.time()
-                t_diff = end - start
-                self.assertLess(t_diff, 0.5)
+                end = time.monotonic()
+                runtime_seconds = end - start
+                self.assertLess(runtime_seconds, 0.5)
                 self.assertEqual(self.counter, 3)
 
     @retry(
@@ -92,17 +92,23 @@ class TestRetryDecorator(unittest.TestCase):
         raise ValueError
 
     def test_retry_immediately(self) -> None:
-        start = time.time()
+        start = time.monotonic()
         self.counter = 0
         with retry_immediately("bar_retry"):
             try:
                 self.namespaced_retry_foo()
 
             except ValueError as e:
-                end = time.time()
-                t_diff = end - start
-                self.assertLess(t_diff, 1)
+                end = time.monotonic()
+                runtime_seconds = end - start
+                self.assertLess(runtime_seconds, 1)
                 self.assertEqual(self.counter, 60)
+
+    def test_mixed_states(self) -> None:
+        with retry_immediately():
+            self.assertRaises(AssertionError, self.test_retry_with_waits)
+        with retry_immediately("bar_retry"):
+            self.test_retry_with_waits()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
When testing code that is using `opnieuw` you don't want to sleep, but do want to retry. This changes adds the following syntax for tests:

``` py
from opnieuw.test_util import retry_immediately

def some_test():
	with retry_immediately():
		# perform some tests that code exception handling via retries
```