### PR TITLE
Add better support for throttling exceptions

### DIFF
--- a/opnieuw/exceptions.py
+++ b/opnieuw/exceptions.py
@@ -3,9 +3,25 @@
 #
 # Licensed under the 3-clause BSD license, see the LICENSE file in the repository root.
 
+from typing import Union
+
 
 class RetryException(Exception):
     """
     Defines a custom RetryException that can be raised for specific errors we
     want to retry on.
     """
+
+
+class BackoffAndRetryException(Exception):
+    """
+    A custom exception that can be raised for specific errors when a fixed
+    wait time before retrying is in order. This can be particularly useful
+    when requests are throttled and the response includes a Retry-After header.
+
+    This will reset the counters for `max_calls_total`
+    and `retry_window_after_first_call_in_seconds`
+    """
+
+    def __init__(self, seconds: Union[int, float]):
+        self.seconds = seconds


### PR DESCRIPTION
In cases where requests fail for non-technical reasons,
we often do not want exponential backoff. Notably when
requests are throttled it is more appropriate to wait
a specified amount of time before retrying. Often we
will learn this from a `Retry-After` header.

This change introduces `BackoffAndRetryException`
which can be used to sleep a fixed amount of time
before retrying.

fixes: #10 