### PR TITLE
Prevent retry state namespaces leak across context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,21 @@
 Changelog
 =========
 
+1.2.0
+-----
+
+Released 2022-05-18.
+
+**Breaking changes**:
+
+- `RetryState` namespaces are now context-local instead of global. This ensures that modifying the
+  retry behavior doesn't bleed unexpectedly when used in concurrent code.
+
+Release highlights:
+
+- Expose `replace_retry_state` context manager to customize the retry behavior for a specific namespace.
+- Add `util.no_retries` context manager to disable retries for a specific namespace.
+
 1.1.0
 -----
 

--- a/opnieuw/__init__.py
+++ b/opnieuw/__init__.py
@@ -3,7 +3,7 @@
 #
 # Licensed under the 3-clause BSD license, see the LICENSE file in the repository root.
 
-from .retries import retry_async, retry
 from .exceptions import RetryException
+from .retries import retry_async, retry
 
 __all__ = ["retry_async", "retry", "RetryException"]

--- a/opnieuw/test_util.py
+++ b/opnieuw/test_util.py
@@ -1,7 +1,6 @@
-from contextlib import contextmanager
-from typing import Iterator, Optional
+from typing import Iterator, Optional, ContextManager
 
-from .retries import DoCall, RetryState, Action, __retry_state_namespaces
+from .retries import DoCall, RetryState, Action, replace_retry_state
 
 
 class WaitLessRetryState(RetryState):
@@ -10,16 +9,10 @@ class WaitLessRetryState(RetryState):
             yield DoCall()
 
 
-@contextmanager
-def retry_immediately(namespace: Optional[str] = None) -> Iterator[None]:
+def retry_immediately(namespace: Optional[str] = None) -> ContextManager[None]:
     """
-    Contextmanager that prevents waits between retries for all `retry` and
+    Returns a contextmanager that prevents waits between retries for all `retry` and
     `retry_async` decorators with the provided namespace. None means all decorators
     without a provided namespace will not wait.
     """
-    old_state = __retry_state_namespaces[namespace]
-    __retry_state_namespaces[namespace] = WaitLessRetryState
-    try:
-        yield
-    finally:
-        __retry_state_namespaces[namespace] = old_state
+    return replace_retry_state(WaitLessRetryState, namespace=namespace)

--- a/opnieuw/util.py
+++ b/opnieuw/util.py
@@ -1,0 +1,17 @@
+from typing import Iterator, Optional, ContextManager
+
+from .retries import DoCall, RetryState, Action, replace_retry_state
+
+
+class NoRetryState(RetryState):
+    def __iter__(self) -> Iterator[Action]:
+        yield DoCall()
+
+
+def no_retries(namespace: Optional[str] = None) -> ContextManager[None]:
+    """
+    Returns a contextmanager that disables retries for all `retry` and
+    `retry_async` decorators with the provided namespace. None means all decorators
+    without a provided namespace will not retry.
+    """
+    return replace_retry_state(NoRetryState, namespace=namespace)

--- a/setup.py
+++ b/setup.py
@@ -3,12 +3,12 @@
 #
 # Licensed under the 3-clause BSD license, see the LICENSE file in the repository root.
 
-import setuptools
+import setuptools  # type: ignore
 
 with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
-__version__ = "1.1.0"
+__version__ = "1.2.0"
 
 setuptools.setup(
     name="opnieuw",
@@ -19,14 +19,14 @@ setuptools.setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/channable/opnieuw",
-    packages=setuptools.find_packages(exclude=('tests',)),
+    packages=setuptools.find_packages(exclude=("tests",)),
     package_data={
-        'opnieuw': ['py.typed'],
+        "opnieuw": ["py.typed"],
     },
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: BSD License",
         "Operating System :: OS Independent",
     ],
-    python_requires=">=3.6",
+    python_requires=">=3.7",
 )

--- a/tests/test_context_local.py
+++ b/tests/test_context_local.py
@@ -1,0 +1,250 @@
+import asyncio
+import threading
+import time
+import typing
+import unittest
+from collections import Counter
+
+from opnieuw.retries import retry_async, retry
+from opnieuw.test_util import retry_immediately
+from opnieuw.util import no_retries
+from tests.utils import AsyncTestCase
+
+
+# The barriers are used to ensure all asyncio tasks/threads have their retry state modified
+# even while the other asyncio tasks/threads are still running.
+# Otherwise, one asyncio task/thread could finish and revert the retry state before the other starts.
+# We want to test the retry state context during concurrency, so the flow should be:
+#
+#        T1         |       T2
+# ------------------|------------------
+# modify state      |
+#                   | modify state
+# wait for others   | wait for others
+# perform test      | perform test
+#                   |
+# wait for others   | wait for others
+# revert state      | revert state
+#
+# This ensures that if the retry state context is leaked across asyncio task or thread,
+# the last one to modify the state will make the others' test fail.
+
+
+class AsyncBarrier:
+    def __init__(self, n: int) -> None:
+        self.n = n
+        self._current = 0
+        self.event = asyncio.Event()
+
+    async def wait(self) -> None:
+        self._current += 1
+        if self._current == self.n:
+            self.event.set()
+        await self.event.wait()
+
+
+class TestAsyncContext(AsyncTestCase):
+    counter: typing.Counter[str] = Counter()
+
+    MAX_TOTAL_CALLS = 3
+
+    @retry_async(
+        retry_on_exceptions=TypeError,
+        max_calls_total=MAX_TOTAL_CALLS,
+        retry_window_after_first_call_in_seconds=3,
+    )
+    async def async_foo(self, counter_key: str) -> None:
+        self.counter[counter_key] += 1
+        # Yield control back to the event loop to give other coro a chance to run
+        await asyncio.sleep(0)
+        raise TypeError
+
+    async def _retry_immediately_coro(
+        self,
+        start_barrier: AsyncBarrier,
+        end_barrier: AsyncBarrier,
+        counter_key: str = "retry_immediately",
+    ) -> None:
+        with retry_immediately():
+            await start_barrier.wait()
+            start = time.monotonic()
+            try:
+                await asyncio.wait_for(self.async_foo(counter_key), timeout=0.5)
+            except TypeError:
+                end = time.monotonic()
+                runtime_seconds = end - start
+                self.assertLess(runtime_seconds, 0.5)
+                self.assertEqual(self.counter[counter_key], self.MAX_TOTAL_CALLS)
+            finally:
+                await end_barrier.wait()
+
+    async def _no_retry_coro(
+        self,
+        start_barrier: AsyncBarrier,
+        end_barrier: AsyncBarrier,
+        counter_key: str = "no_retry",
+    ) -> None:
+        with no_retries():
+            await start_barrier.wait()
+            start = time.monotonic()
+            try:
+                await asyncio.wait_for(self.async_foo(counter_key), timeout=0.5)
+            except TypeError:
+                end = time.monotonic()
+                runtime_seconds = end - start
+                self.assertLess(runtime_seconds, 0.5)
+                # We expect only one call since retries were disabled
+                self.assertEqual(self.counter[counter_key], 1)
+            finally:
+                await end_barrier.wait()
+
+    async def _no_retry_with_nested_immediately_retry_coro(
+        self,
+        start_barrier: AsyncBarrier,
+        end_barrier: AsyncBarrier,
+        counter_key: str = "no_retry_with_nested_retry_immediately",
+    ) -> None:
+        with no_retries():
+            nested_task = asyncio.create_task(
+                self._retry_immediately_coro(
+                    start_barrier, end_barrier, counter_key="nested_retry_immediately"
+                )
+            )
+            await start_barrier.wait()
+            start = time.monotonic()
+            try:
+                await asyncio.wait_for(self.async_foo(counter_key), timeout=0.5)
+                await nested_task
+            except TypeError:
+                end = time.monotonic()
+                runtime_seconds = end - start
+                self.assertLess(runtime_seconds, 0.5)
+                # We expect only one call since retries were disabled
+                self.assertEqual(self.counter[counter_key], 1)
+            finally:
+                await end_barrier.wait()
+
+    def test_async_retry_state_context(self) -> None:
+        """
+        Test that the retry state is only modified in the context of an asyncio.Task
+        and not globally.
+        """
+
+        async def _test_inner() -> None:
+            self.counter = Counter()
+
+            start_barrier = AsyncBarrier(2)
+            end_barrier = AsyncBarrier(2)
+
+            await asyncio.gather(
+                self._no_retry_coro(start_barrier, end_barrier),
+                self._retry_immediately_coro(start_barrier, end_barrier),
+            )
+
+            # retry state should not leak between tasks
+            assert self.counter.most_common() == [
+                ("retry_immediately", 3),
+                ("no_retry", 1),
+            ]
+
+        self._run_async(_test_inner())
+
+    def test_async_retry_state_context_nested(self) -> None:
+        """
+        Test that the retry state is only modified in the context of an asyncio.Task
+        and not globally. In this case the tasks are nested.
+        """
+
+        async def _test_inner() -> None:
+            self.counter = Counter()
+
+            start_barrier = AsyncBarrier(2)
+            end_barrier = AsyncBarrier(2)
+
+            await self._no_retry_with_nested_immediately_retry_coro(
+                start_barrier, end_barrier
+            )
+
+            # Nested task should be able to override retry state
+            # without leaking into parent, and vice versa
+            assert self.counter.most_common() == [
+                ("nested_retry_immediately", 3),
+                ("no_retry_with_nested_retry_immediately", 1),
+            ]
+
+        self._run_async(_test_inner())
+
+
+class TestThreadedContext(unittest.TestCase):
+    counter: typing.Counter[str] = Counter()
+
+    @retry(
+        retry_on_exceptions=TypeError,
+        max_calls_total=3,
+        retry_window_after_first_call_in_seconds=3,
+    )
+    def foo(self, counter_key: str) -> None:
+        self.counter[counter_key] += 1
+        raise TypeError
+
+    def test_threaded_retry_state_context(self) -> None:
+        def _retry_immediately_inner(
+            start_barrier: threading.Barrier, end_barrier: threading.Barrier
+        ) -> None:
+            counter_key = "retry_immediately"
+
+            with retry_immediately():
+                start_barrier.wait()
+                start = time.monotonic()
+                try:
+                    self.foo(counter_key)
+                except TypeError:
+                    end = time.monotonic()
+                    runtime_seconds = end - start
+                    self.assertLess(runtime_seconds, 0.5)
+                    self.assertEqual(self.counter[counter_key], 3)
+                finally:
+                    end_barrier.wait()
+
+        def _no_retry_inner(
+            start_barrier: threading.Barrier, end_barrier: threading.Barrier
+        ) -> None:
+            counter_key = "no_retry"
+
+            with no_retries():
+                start_barrier.wait()
+                start = time.monotonic()
+                try:
+                    self.foo(counter_key)
+                except TypeError:
+                    end = time.monotonic()
+                    runtime_seconds = end - start
+                    self.assertLess(runtime_seconds, 0.5)
+                    self.assertEqual(self.counter[counter_key], 1)
+                finally:
+                    end_barrier.wait()
+
+        self.counter = Counter()
+        start_barrier = threading.Barrier(2)
+        end_barrier = threading.Barrier(2)
+        threads = [
+            threading.Thread(target=_no_retry_inner, args=(start_barrier, end_barrier)),
+            threading.Thread(
+                target=_retry_immediately_inner, args=(start_barrier, end_barrier)
+            ),
+        ]
+
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        # retry state should not leak between threads
+        assert self.counter.most_common() == [
+            ("retry_immediately", 3),
+            ("no_retry", 1),
+        ]
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,25 @@
+import asyncio
+import unittest
+from contextlib import contextmanager
+from typing import Iterator, Awaitable, TypeVar
+
+T = TypeVar("T")
+
+
+class AsyncTestCase(unittest.TestCase):
+    """
+    A very barebone TestCase that provides a utility to run an async event loop
+    """
+
+    @contextmanager
+    def _new_loop(self) -> Iterator[asyncio.AbstractEventLoop]:
+        policy = asyncio.get_event_loop_policy()
+        loop = policy.new_event_loop()
+        try:
+            yield loop
+        finally:
+            loop.close()
+
+    def _run_async(self, fut: Awaitable[T]) -> T:
+        with self._new_loop() as loop:
+            return loop.run_until_complete(fut)


### PR DESCRIPTION
Currently, the retry state namespaces leak between asyncio tasks or threads. This is important in concurrent code where the retry states should not affect others. For example it might make sense to disable retries under certain conditions (I also added an utility for this)

This PR adds `contexvars` when usable (>= 3.7) which prevent these leaks.