### PR TITLE
Update typing and use ``ParamSpec``

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -16,6 +16,7 @@ blocks:
         - name: "Unit tests"
           commands:
             - "checkout"
+            - "python3.7 -m pip install ."
             - "python3.7 -m unittest discover tests"
 
   - name: "Build and ship"

--- a/opnieuw/retries.py
+++ b/opnieuw/retries.py
@@ -4,28 +4,19 @@
 # Licensed under the 3-clause BSD license, see the LICENSE file in the repository root.
 
 # pylint: disable=raising-bad-type
+
+from __future__ import annotations
+
 import asyncio
 import functools
 import logging
 import random
 import time
 from collections import defaultdict
+from collections.abc import Iterator
 from contextlib import contextmanager
 from contextvars import ContextVar
-from typing import (
-    Awaitable,
-    cast,
-    Any,
-    Callable,
-    Iterator,
-    NamedTuple,
-    Tuple,
-    Type,
-    TypeVar,
-    Union,
-    Dict,
-    Optional,
-)
+from typing import Any, Awaitable, Callable, NamedTuple, TypeVar, Union, cast
 
 from .clock import Clock, MonotonicClock
 
@@ -127,7 +118,7 @@ class RetryState:
             # attempt the actual function call
             yield DoCall()
 
-            wait_seconds = self.base_in_seconds * 2 ** attempt
+            wait_seconds = self.base_in_seconds * 2**attempt
             seconds_left = self.deadline_second - self.clock.seconds_since_epoch()
 
             # signal that we need to sleep
@@ -139,18 +130,18 @@ class RetryState:
             )
 
 
-__retry_state_namespaces: Dict[
-    Optional[str], ContextVar[Type[RetryState]]
-] = defaultdict(lambda: ContextVar("opnieuw_default_retry_state", default=RetryState))
+__retry_state_namespaces: dict[str | None, ContextVar[type[RetryState]]] = defaultdict(
+    lambda: ContextVar("opnieuw_default_retry_state", default=RetryState)
+)
 
 
-def _get_retry_state_class(namespace: Optional[str]) -> Type[RetryState]:
+def _get_retry_state_class(namespace: str | None) -> type[RetryState]:
     return __retry_state_namespaces[namespace].get()
 
 
 @contextmanager
 def replace_retry_state(
-    state: Type[RetryState], *, namespace: Optional[str] = None
+    state: type[RetryState], *, namespace: str | None = None
 ) -> Iterator[None]:
     """
     A context manager that replaces the state of the specified namespace with the
@@ -171,10 +162,10 @@ def replace_retry_state(
 
 def retry(
     *,
-    retry_on_exceptions: Union[Type[Exception], Tuple[Type[Exception], ...]],
+    retry_on_exceptions: type[Exception] | tuple[type[Exception], ...],
     max_calls_total: int = 3,
     retry_window_after_first_call_in_seconds: int = 60,
-    namespace: Optional[str] = None,
+    namespace: str | None = None,
 ) -> Callable[[F], F]:
     """
     Retry a function using a Full Jitter exponential backoff.
@@ -290,10 +281,10 @@ def retry(
 
 def retry_async(
     *,
-    retry_on_exceptions: Union[Type[Exception], Tuple[Type[Exception], ...]],
+    retry_on_exceptions: type[Exception] | tuple[type[Exception], ...],
     max_calls_total: int = 3,
     retry_window_after_first_call_in_seconds: int = 60,
-    namespace: Optional[str] = None,
+    namespace: str | None = None,
 ) -> Callable[[AF], AF]:
     def decorator(f: AF) -> AF:
         @functools.wraps(f)

--- a/setup.py
+++ b/setup.py
@@ -29,4 +29,7 @@ setuptools.setup(
         "Operating System :: OS Independent",
     ],
     python_requires=">=3.7",
+    install_requires=[
+        "typing-extensions>=3.10.0;python_version<'3.10'",
+    ],
 )


### PR DESCRIPTION
I was debugging another issue and found that we use `casts` and quite old concepts here. In most of our project this won't add a dependency on `typing-extensions` and in others it is something that `mypy` will almost take in as well.

Think it is overall a nice improvement to the code and makes it more type safe.
In fact, it also showed an issue in that we would start returning `None` from the wrapped function if there was no `last_exception`. Reading the code that doesn't make a lot of sense as we don't want to add `None` to all signatures of the functions we wrap with `opnieuw`. In fact I think we should assert that `last_exception` is set (which it should be if you follow the logic).

Tagging @LeonardBesson as reviewer as they were the ones to last touch this project.