### PR TITLE
Fix the name of ``TestClock``, upgrade code and release new version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,30 @@
 Changelog
 =========
 
+2.0.0
+-----
+
+Released 2022-05-18.
+
+**Breaking changes**:
+
+- `clock.TestClock` was renamed to `clock.DummyClock`.
+
+Release highlights:
+
+- Rename `clock.TestClock` to `clock.DummyClock`.
+- Relint and upgrade the codebase.
+- Fix a typing issues for `retry_async`.
+
+1.2.1
+-----
+
+Released 2023-05-04.
+
+Release highlights:
+
+- Use more modern typing concepts such as `ParamSpec`.
+
 1.2.0
 -----
 

--- a/opnieuw/__init__.py
+++ b/opnieuw/__init__.py
@@ -4,6 +4,6 @@
 # Licensed under the 3-clause BSD license, see the LICENSE file in the repository root.
 
 from .exceptions import RetryException
-from .retries import retry_async, retry
+from .retries import retry, retry_async
 
 __all__ = ["retry_async", "retry", "RetryException"]

--- a/opnieuw/clock.py
+++ b/opnieuw/clock.py
@@ -20,7 +20,7 @@ class MonotonicClock(Clock):
         return time.monotonic()
 
 
-class TestClock(Clock):
+class DummyClock(Clock):
     """Fake clock for use in tests."""
 
     def __init__(self) -> None:

--- a/opnieuw/retries.py
+++ b/opnieuw/retries.py
@@ -14,7 +14,7 @@ import random
 import sys
 import time
 from collections import defaultdict
-from collections.abc import Awaitable, Callable, Iterator
+from collections.abc import Callable, Coroutine, Iterator
 from contextlib import contextmanager
 from contextvars import ContextVar
 from typing import NamedTuple, TypeVar, Union
@@ -226,7 +226,6 @@ def retry(
     def decorator(f: Callable[P, R]) -> Callable[P, R]:
         @functools.wraps(f)
         def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
-
             last_exception = None
 
             retry_state = _get_retry_state_class(namespace)(
@@ -236,7 +235,6 @@ def retry(
             )
 
             for retry_action in retry_state:
-
                 if isinstance(retry_action, DoCall):
                     try:
                         return f(*args, **kwargs)
@@ -279,11 +277,14 @@ def retry_async(
     max_calls_total: int = 3,
     retry_window_after_first_call_in_seconds: int = 60,
     namespace: str | None = None,
-) -> Callable[[Callable[P, Awaitable[R]]], Callable[P, Awaitable[R]]]:
-    def decorator(f: Callable[P, Awaitable[R]]) -> Callable[P, Awaitable[R]]:
+) -> Callable[
+    [Callable[P, Coroutine[None, None, R]]], Callable[P, Coroutine[None, None, R]]
+]:
+    def decorator(
+        f: Callable[P, Coroutine[None, None, R]]
+    ) -> Callable[P, Coroutine[None, None, R]]:
         @functools.wraps(f)
         async def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
-
             last_exception = None
 
             retry_state = _get_retry_state_class(namespace)(
@@ -293,7 +294,6 @@ def retry_async(
             )
 
             for retry_action in retry_state:
-
                 if isinstance(retry_action, DoCall):
                     try:
                         return await f(*args, **kwargs)

--- a/opnieuw/test_util.py
+++ b/opnieuw/test_util.py
@@ -1,6 +1,9 @@
-from typing import Iterator, Optional, ContextManager
+from __future__ import annotations
 
-from .retries import DoCall, RetryState, Action, replace_retry_state
+from collections.abc import Iterator
+from contextlib import AbstractContextManager
+
+from .retries import Action, DoCall, RetryState, replace_retry_state
 
 
 class WaitLessRetryState(RetryState):
@@ -9,7 +12,7 @@ class WaitLessRetryState(RetryState):
             yield DoCall()
 
 
-def retry_immediately(namespace: Optional[str] = None) -> ContextManager[None]:
+def retry_immediately(namespace: str | None = None) -> AbstractContextManager[None]:
     """
     Returns a contextmanager that prevents waits between retries for all `retry` and
     `retry_async` decorators with the provided namespace. None means all decorators

--- a/opnieuw/util.py
+++ b/opnieuw/util.py
@@ -1,6 +1,9 @@
-from typing import Iterator, Optional, ContextManager
+from __future__ import annotations
 
-from .retries import DoCall, RetryState, Action, replace_retry_state
+from collections.abc import Iterator
+from contextlib import AbstractContextManager
+
+from .retries import Action, DoCall, RetryState, replace_retry_state
 
 
 class NoRetryState(RetryState):
@@ -8,7 +11,7 @@ class NoRetryState(RetryState):
         yield DoCall()
 
 
-def no_retries(namespace: Optional[str] = None) -> ContextManager[None]:
+def no_retries(namespace: str | None = None) -> AbstractContextManager[None]:
     """
     Returns a contextmanager that disables retries for all `retry` and
     `retry_async` decorators with the provided namespace. None means all decorators

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ import setuptools  # type: ignore
 with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
-__version__ = "1.2.1"
+__version__ = "2.0.0"
 
 setuptools.setup(
     name="opnieuw",

--- a/tests/test_context_local.py
+++ b/tests/test_context_local.py
@@ -1,15 +1,15 @@
+from __future__ import annotations
+
 import asyncio
 import threading
 import time
-import typing
 import unittest
 from collections import Counter
 
-from opnieuw.retries import retry_async, retry
+from opnieuw.retries import retry, retry_async
 from opnieuw.test_util import retry_immediately
 from opnieuw.util import no_retries
 from tests.utils import AsyncTestCase
-
 
 # The barriers are used to ensure all asyncio tasks/threads have their retry state modified
 # even while the other asyncio tasks/threads are still running.
@@ -44,7 +44,7 @@ class AsyncBarrier:
 
 
 class TestAsyncContext(AsyncTestCase):
-    counter: typing.Counter[str] = Counter()
+    counter: Counter[str] = Counter()
 
     MAX_TOTAL_CALLS = 3
 
@@ -176,7 +176,7 @@ class TestAsyncContext(AsyncTestCase):
 
 
 class TestThreadedContext(unittest.TestCase):
-    counter: typing.Counter[str] = Counter()
+    counter: Counter[str] = Counter()
 
     @retry(
         retry_on_exceptions=TypeError,

--- a/tests/test_opnieuw.py
+++ b/tests/test_opnieuw.py
@@ -6,8 +6,8 @@
 import time
 import unittest
 
-from opnieuw.clock import TestClock, MonotonicClock
-from opnieuw.retries import RetryState, DoCall, retry
+from opnieuw.clock import DummyClock, MonotonicClock
+from opnieuw.retries import DoCall, RetryState, retry
 from opnieuw.test_util import retry_immediately
 
 
@@ -25,7 +25,7 @@ class TestRetryState(unittest.TestCase):
 
 class TestRetryClock(unittest.TestCase):
     def setUp(self) -> None:
-        self.clock = TestClock()
+        self.clock = DummyClock()
 
     def test_negative_time_value(self) -> None:
         try:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,7 +1,10 @@
+from __future__ import annotations
+
 import asyncio
 import unittest
+from collections.abc import Coroutine, Iterator
 from contextlib import contextmanager
-from typing import Iterator, Awaitable, TypeVar
+from typing import TypeVar
 
 T = TypeVar("T")
 
@@ -20,6 +23,6 @@ class AsyncTestCase(unittest.TestCase):
         finally:
             loop.close()
 
-    def _run_async(self, fut: Awaitable[T]) -> T:
+    def _run_async(self, fut: Coroutine[None, None, T]) -> T:
         with self._new_loop() as loop:
             return loop.run_until_complete(fut)


### PR DESCRIPTION
Closes https://github.com/channable/opnieuw/issues/18.

Decided to release `2.0.0` as this is probably considered a breaking change.