### PR TITLE
Remove concept of ``DoCall``

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,24 @@
 Changelog
 =========
 
+3.0.0
+-----
+
+Work in progress.
+
+**Breaking changes**:
+
+- `DoCall` has been removed. `retry` and `retry_async` will now execute the decorated
+  function immediately and wait as defined by `DoWait`. If you need an immediate retry,
+  you can `yield DoWait(0, 0, 0, 0)`.`
+- `Action` has been removed as there is now only a `DoWait` class.
+
+Release highlights:
+
+- Remove `DoCall` and only have a `DoWait` to simplify the retyring logic.
+- Remove `Action` as it is no longer required.
+
+
 2.0.0
 -----
 

--- a/opnieuw/retries.py
+++ b/opnieuw/retries.py
@@ -107,6 +107,12 @@ class RetryState:
         )
 
     def __iter__(self) -> Iterator[DoWait]:
+        """
+        Yield collections of info that tell the retry decorators how long to wait.
+
+        The retry decorators will execute the function once for every DoWait instance
+        they encounter.
+        """
         for attempt in range(0, self.max_calls_total):
             wait_seconds = self.base_in_seconds * 2**attempt
             seconds_left = self.deadline_second - self.clock.seconds_since_epoch()

--- a/opnieuw/test_util.py
+++ b/opnieuw/test_util.py
@@ -3,13 +3,14 @@ from __future__ import annotations
 from collections.abc import Iterator
 from contextlib import AbstractContextManager
 
-from .retries import Action, DoCall, RetryState, replace_retry_state
+from .retries import DoWait, RetryState, replace_retry_state
 
 
 class WaitLessRetryState(RetryState):
-    def __iter__(self) -> Iterator[Action]:
+    def __iter__(self) -> Iterator[DoWait]:
         for _ in range(self.max_calls_total):
-            yield DoCall()
+            # Yield a DoWait that leads to no waiting
+            yield DoWait(0, 0, 0, 0)
 
 
 def retry_immediately(namespace: str | None = None) -> AbstractContextManager[None]:

--- a/opnieuw/util.py
+++ b/opnieuw/util.py
@@ -3,12 +3,13 @@ from __future__ import annotations
 from collections.abc import Iterator
 from contextlib import AbstractContextManager
 
-from .retries import Action, DoCall, RetryState, replace_retry_state
+from .retries import DoWait, RetryState, replace_retry_state
 
 
 class NoRetryState(RetryState):
-    def __iter__(self) -> Iterator[Action]:
-        yield DoCall()
+    def __iter__(self) -> Iterator[DoWait]:
+        # Yield a DoWait that leads to no waiting
+        yield DoWait(0, 0, 0, 0)
 
 
 def no_retries(namespace: str | None = None) -> AbstractContextManager[None]:

--- a/tests/test_opnieuw.py
+++ b/tests/test_opnieuw.py
@@ -7,7 +7,7 @@ import time
 import unittest
 
 from opnieuw.clock import DummyClock, MonotonicClock
-from opnieuw.retries import DoCall, RetryState, retry
+from opnieuw.retries import DoWait, RetryState, retry
 from opnieuw.test_util import retry_immediately
 
 
@@ -19,8 +19,9 @@ class TestRetryState(unittest.TestCase):
             retry_window_after_first_call_in_seconds=3,
         )
 
-        for rt in retry_state:
-            self.assertIsInstance(rt, DoCall)
+        for _ in retry_state:
+            # This kind of RetryState should yield no states
+            assert False
 
 
 class TestRetryClock(unittest.TestCase):


### PR DESCRIPTION
I discussed offline with @jochemb that we might want to clean up the code of `opnieuw` a little bit before pursuing https://github.com/channable/opnieuw/pull/22.

The concept of `DoCall` doesn't add much currently and just serves as an empty placeholder. We can probably clean up the API of `DoWait` as well and then reword some of the Changelog but this is would be a good start in my opinion.
