### PR TITLE
Introduce ``BackoffCalculator``

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,24 @@
 Changelog
 =========
 
+3.0.0
+-----
+
+Work in progress.
+
+**Breaking changes**:
+
+- `DoCall`, `DoWait` and `RetryState` have been removed. They have been replaced by
+  `BackoffCalculator`. This class exposes a method `get_backoff`. This method should return either
+  a `float` representing the time to wait or `None` if there should be no more retries/waits.
+
+Release highlights:
+
+- Remove `DoCall`, `DoWait` and `RetryState`.
+- Use `BackoffCalculator` to keep track of the time to wait between retries and refactor
+  retrying logic accordingly.
+
+
 2.0.0
 -----
 

--- a/opnieuw/util.py
+++ b/opnieuw/util.py
@@ -1,14 +1,13 @@
 from __future__ import annotations
 
-from collections.abc import Iterator
 from contextlib import AbstractContextManager
 
-from .retries import Action, DoCall, RetryState, replace_retry_state
+from .retries import BackoffCalculator, replace_backoff_calculator
 
 
-class NoRetryState(RetryState):
-    def __iter__(self) -> Iterator[Action]:
-        yield DoCall()
+class NoRetryBackoff(BackoffCalculator):
+    def get_backoff(self) -> float | None:
+        return None
 
 
 def no_retries(namespace: str | None = None) -> AbstractContextManager[None]:
@@ -17,4 +16,4 @@ def no_retries(namespace: str | None = None) -> AbstractContextManager[None]:
     `retry_async` decorators with the provided namespace. None means all decorators
     without a provided namespace will not retry.
     """
-    return replace_retry_state(NoRetryState, namespace=namespace)
+    return replace_backoff_calculator(NoRetryBackoff, namespace=namespace)

--- a/tests/test_context_local.py
+++ b/tests/test_context_local.py
@@ -124,10 +124,10 @@ class TestAsyncContext(AsyncTestCase):
             finally:
                 await end_barrier.wait()
 
-    def test_async_retry_state_context(self) -> None:
+    def test_async_backoff_calculator_context(self) -> None:
         """
-        Test that the retry state is only modified in the context of an asyncio.Task
-        and not globally.
+        Test that the backoff calculator is only modified in the context of an
+        asyncio.Task and not globally.
         """
 
         async def _test_inner() -> None:
@@ -149,10 +149,10 @@ class TestAsyncContext(AsyncTestCase):
 
         self._run_async(_test_inner())
 
-    def test_async_retry_state_context_nested(self) -> None:
+    def test_async_backoff_calculator_context_nested(self) -> None:
         """
-        Test that the retry state is only modified in the context of an asyncio.Task
-        and not globally. In this case the tasks are nested.
+        Test that the backoff calculator is only modified in the context of an
+        asyncio.Task and not globally. In this case the tasks are nested.
         """
 
         async def _test_inner() -> None:
@@ -165,7 +165,7 @@ class TestAsyncContext(AsyncTestCase):
                 start_barrier, end_barrier
             )
 
-            # Nested task should be able to override retry state
+            # Nested task should be able to override backoff calculator
             # without leaking into parent, and vice versa
             assert self.counter.most_common() == [
                 ("nested_retry_immediately", 3),
@@ -187,7 +187,7 @@ class TestThreadedContext(unittest.TestCase):
         self.counter[counter_key] += 1
         raise TypeError
 
-    def test_threaded_retry_state_context(self) -> None:
+    def test_threaded_backoff_calculator_context(self) -> None:
         def _retry_immediately_inner(
             start_barrier: threading.Barrier, end_barrier: threading.Barrier
         ) -> None:
@@ -239,7 +239,7 @@ class TestThreadedContext(unittest.TestCase):
         for t in threads:
             t.join()
 
-        # retry state should not leak between threads
+        # backoff calculator should not leak between threads
         assert self.counter.most_common() == [
             ("retry_immediately", 3),
             ("no_retry", 1),

--- a/tests/test_opnieuw.py
+++ b/tests/test_opnieuw.py
@@ -7,20 +7,20 @@ import time
 import unittest
 
 from opnieuw.clock import DummyClock, MonotonicClock
-from opnieuw.retries import DoCall, RetryState, retry
+from opnieuw.retries import BackoffCalculator, retry
 from opnieuw.test_util import retry_immediately
 
 
-class TestRetryState(unittest.TestCase):
-    def test_never_stop(self) -> None:
-        retry_state = RetryState(
+class TestBackoffCalculator(unittest.TestCase):
+    def test_max_calls_is_zero(self) -> None:
+        retry_state = BackoffCalculator(
             MonotonicClock(),
             max_calls_total=0,
             retry_window_after_first_call_in_seconds=3,
         )
 
-        for rt in retry_state:
-            self.assertIsInstance(rt, DoCall)
+        # This kind of BackoffCalculator should only return None
+        self.assertEqual(None, retry_state.get_backoff())
 
 
 class TestRetryClock(unittest.TestCase):
@@ -66,7 +66,7 @@ class TestRetryDecorator(unittest.TestCase):
         except TypeError as e:
             end = time.monotonic()
             runtime_seconds = end - start
-            self.assertGreater(runtime_seconds, 0.5)
+            self.assertGreater(runtime_seconds, 0.3)
             self.assertEqual(self.counter, 3)
 
     def test_retry_immediately_global(self) -> None:


### PR DESCRIPTION
This replaces the `RetryState` for a much simpler state object that exposes a simple method to get the next period to wait.

I believe this makes the code a lot easier to follow: `WaitState` is responsible for all time calculations and the retry decorators are responsible for handling the returned time periods.
Next step would be to start chaining exceptions.