### PR TITLE
Update CI image to Ubuntu 22.04

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -3,8 +3,8 @@ name: "Opnieuw"
 
 agent:
   machine:
-    type: "e1-standard-2"
-    os_image: "ubuntu1804"
+    type: "e2-standard-2"
+    os_image: "ubuntu2204"
 
 
 blocks:
@@ -16,8 +16,8 @@ blocks:
         - name: "Unit tests"
           commands:
             - "checkout"
-            - "python3.8 -m pip install ."
-            - "python3.8 -m unittest discover tests"
+            - "python -m pip install ."
+            - "python -m unittest discover tests"
 
   - name: "Build and ship"
 


### PR DESCRIPTION
This updates the CI image from Ubuntu 18.04 to 22.04. Until very recently the 22.04 image was still called experimental/beta [here](https://docs.semaphoreci.com/ci-cd-environment/ubuntu-22.04-image/), but they seem to have removed that.