### PR TITLE
Support custom functions

### DIFF
--- a/opnieuw/retries.py
+++ b/opnieuw/retries.py
@@ -300,8 +300,18 @@ def retry_async(
                         e.__cause__ = last_exception
 
                     last_exception = e
-                    if not isinstance(e, retry_on_exceptions):
-                        raise
+                    params = (
+                        retry_on_exceptions if type(retry_on_exceptions) == tuple else
+                        (retry_on_exceptions,)
+                    )
+                    errs = tuple([param for param in params if type(param).__name__ == 'type'])
+                    if not isinstance(e, errs):
+                        callbacks = [param(e) for param in params if type(param).__name__ == 'function']
+                        if not callbacks:
+                            raise
+
+                        if not any(callbacks):
+                            raise
 
                     if (sleep_seconds := backoff_calculator.get_backoff()) is None:
                         raise

--- a/tests/test_opnieuw.py
+++ b/tests/test_opnieuw.py
@@ -179,12 +179,15 @@ class TestExceptionChaining(unittest.TestCase):
         try:
             self.foo(IndexError)
         except Exception as e:
-            self.assertTrue(self.counter < 3 and isinstance(e, IndexError))
+            self.assertLess(self.counter, 3)
+            self.assertTrue(isinstance(e, IndexError))
 
         try:
+            self.counter = 0
             self.foo(ValueError)
         except Exception as e:
-            self.assertTrue(self.counter >= 3 and isinstance(e, ValueError))
+            self.assertGreaterEqual(self.counter, 3)
+            self.assertTrue(isinstance(e, ValueError))
 
 
 class TestWarningOnOneRetry(unittest.TestCase):


### PR DESCRIPTION
Extends support for custom functions as described in https://github.com/channable/opnieuw/issues/32

For example,
```python
def should_retry():
    return bool(random.randint(0, 1))

@retry(
    retry_on_exceptions=should_retry,
    ...
)
def foo():
    ...

@retry(
    retry_on_exceptions=(TypeError, ValueError, should_retry),
    ...
)
def bar():
    ...
```

I've intentionally not attempted to include per-exception grouping as I feel those are corner cases that can be handled inside the custom functions instead.