### PR TITLE
Fix release script

### DIFF
--- a/.semaphore/publish-or-perish.sh
+++ b/.semaphore/publish-or-perish.sh
@@ -6,12 +6,18 @@
 
 set -efuo pipefail
 
-git fetch --tags
-TAG=v$(python setup.py --version)
+sudo pip install toml
+TAG=v$(grep -Po '__version__ = .\K[0-9\\.]+' opnieuw/__init__.py)
 # If the tag already exist this command will fail and the job will exit
 # without raising an error. Otherwise, we will build the project,
 # publish to PyPi, and push the tag to github.
+git fetch --tags
 git tag "$TAG" || exit 0
+
+sudo pip install build
+python3 -m build
+
 sudo pip install twine
-twine upload --skip-existing dist/*
+python3 -m twine upload --skip-existing dist/*
+
 git push origin "$TAG"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Work in progress.
 Release highlights:
 
 - A `UserWarning` will be raised whenever `max_calls_total` is lower than 2.
-- Replace setup.py by pyproject.toml and add Python 3.13 support
+- Replace setup.py by pyproject.toml and add Python 3.13 + 3.14 support
 
 3.0.0
 -----


### PR DESCRIPTION
`.semaphore/publish-or-perish.sh` needed to be updated to work with the changes of https://github.com/channable/opnieuw/pull/36.

The script is now based on https://github.com/channable/heliclockter/blob/master/.semaphore/publish-or-perish.sh