### PR TITLE
Log retried exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 Changelog
 =========
 
+3.4.0
+-----
+
+Released 2026-07-02.
+
+Release highlights:
+
+- Improve debug logging by including the exception type that triggered the retry.
+
 3.3.0
 -----
 

--- a/opnieuw/__init__.py
+++ b/opnieuw/__init__.py
@@ -8,4 +8,4 @@ from .retries import retry, retry_async
 
 __all__ = ["retry_async", "retry", "RetryException"]
 
-__version__ = "3.3.0"
+__version__ = "3.4.0"

--- a/opnieuw/retries.py
+++ b/opnieuw/retries.py
@@ -94,32 +94,42 @@ class BackoffCalculator:
         )
         self.backoffs = 0
 
-    def get_backoff(self) -> float | None:
+    def get_backoff(self, exception: Exception | None = None) -> float | None:
         """
         Return the amount of seconds to backoff.
 
         None indicates that there should be no more backoffs. The retry decorators
         are responsible for raising the last exception if None is returned.
+        The exception parameter is provided to allow for logging of the exception type
+        that caused the backoff, which can be useful for debugging purposes.
         """
         backoff_seconds = self.base_in_seconds * 2**self.backoffs
         jittered_backoff = random.uniform(0.0, backoff_seconds)
 
+        exception_name = type(exception).__name__ if exception is not None else "N/A"
+
         self.backoffs += 1
         if self.backoffs >= self.max_calls_total:
-            logger.debug(f"Used up all {self.backoffs} retries.")
+            logger.debug(
+                f"Used up all {self.backoffs} retries. "
+                f"Would have retried due to exception type: {exception_name}."
+            )
             return None
 
         remaining_window = self.deadline_second - self.clock.seconds_since_epoch()
         if jittered_backoff > remaining_window:
             logger.debug(
-                f"Next attempt would be after retry deadline (remaining window: {remaining_window:.3f}s), not retrying."
+                f"Next attempt would be after retry deadline (remaining window: {remaining_window:.3f}s), not retrying. "
+                f"Would have retried due to exception type: {exception_name}."
             )
             return None
 
         logger.debug(
             f"Backoff for {jittered_backoff:.3f} seconds after attempt {self.backoffs}/{self.max_calls_total} "
-            f"(remaining window: {remaining_window:.3f}s)"
+            f"(remaining window: {remaining_window:.3f}s). "
+            f"Will retry due to exception type: {exception_name}."
         )
+
         return jittered_backoff
 
 
@@ -272,9 +282,8 @@ def retry(
                         if not isinstance(e, retry_on_exceptions):
                             raise
 
-                        if (sleep_seconds := backoff_calculator.get_backoff()) is None:
+                        if (sleep_seconds := backoff_calculator.get_backoff(e)) is None:
                             raise
-
 
                         await asyncio.sleep(sleep_seconds)
             return functools.wraps(f)(async_wrapper)
@@ -298,7 +307,7 @@ def retry(
                         if not isinstance(e, retry_on_exceptions):
                             raise
 
-                        if (sleep_seconds := backoff_calculator.get_backoff()) is None:
+                        if (sleep_seconds := backoff_calculator.get_backoff(e)) is None:
                             raise
 
                         time.sleep(sleep_seconds)

--- a/opnieuw/test_util.py
+++ b/opnieuw/test_util.py
@@ -6,7 +6,7 @@ from .retries import BackoffCalculator, replace_backoff_calculator
 
 
 class WaitLessBackoff(BackoffCalculator):
-    def get_backoff(self) -> float | None:
+    def get_backoff(self, exception: Exception | None = None) -> float | None:
         self.backoffs += 1
         if self.backoffs >= self.max_calls_total:
             return None

--- a/opnieuw/util.py
+++ b/opnieuw/util.py
@@ -6,7 +6,7 @@ from .retries import BackoffCalculator, replace_backoff_calculator
 
 
 class NoRetryBackoff(BackoffCalculator):
-    def get_backoff(self) -> float | None:
+    def get_backoff(self, exception: Exception | None = None) -> float | None:
         return None
 
 

--- a/tests/test_opnieuw.py
+++ b/tests/test_opnieuw.py
@@ -23,7 +23,7 @@ class TestBackoffCalculator(unittest.TestCase):
         )
 
         # This kind of BackoffCalculator should only return None
-        self.assertEqual(None, retry_state.get_backoff())
+        self.assertEqual(None, retry_state.get_backoff(exception=Exception()))
 
 
 class TestRetryClock(unittest.TestCase):


### PR DESCRIPTION
When a tuple is provided for `retry_on_exceptions`, it can be useful to log the specific exception that is causing the retry.