### PR TITLE
Fix runtime dependencies and bump to `4.0.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 Changelog
 =========
 
+4.0.0
+-----
+
+Released 2026-07-13.
+
+Release highlights:
+
+- Drop Python 3.8 and 3.9 support; `opnieuw` now requires Python 3.10+.
+- Remove the `typing-extensions` runtime dependency on Python 3.13+.
+
 3.4.0
 -----
 

--- a/opnieuw/__init__.py
+++ b/opnieuw/__init__.py
@@ -8,4 +8,4 @@ from .retries import retry, retry_async
 
 __all__ = ["retry_async", "retry", "RetryException"]
 
-__version__ = "3.4.0"
+__version__ = "4.0.0"

--- a/opnieuw/retries.py
+++ b/opnieuw/retries.py
@@ -14,18 +14,17 @@ import logging
 import random
 import sys
 import time
-import typing_extensions
 import warnings
 from collections import defaultdict
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from contextvars import ContextVar
-from typing import TypeVar, Awaitable, cast, overload
+from typing import Awaitable, ParamSpec, TypeVar, cast, overload
 
-if sys.version_info < (3, 10):
-    from typing_extensions import ParamSpec
+if sys.version_info < (3, 13):
+    from typing_extensions import deprecated
 else:
-    from typing import ParamSpec
+    from warnings import deprecated
 
 from .clock import Clock, MonotonicClock
 
@@ -317,7 +316,7 @@ def retry(
 # We expose `retry_async` for backwards-compatibility.
 # However, nowadays the main `retry` decorator is able
 # to accept both sync and async functions directly.
-@typing_extensions.deprecated("Use the normal `retry` instead, as works for both sync and async functions", category=None)
+@deprecated("Use the normal `retry` instead, as works for both sync and async functions", category=None)
 def retry_async(
     *,
     retry_on_exceptions: type[Exception] | tuple[type[Exception], ...],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,29 +6,26 @@ build-backend = 'setuptools.build_meta'
 name = 'opnieuw'
 description = 'Retries for humans'
 readme = 'README.md'
-requires-python = '>=3.8'
+requires-python = '>=3.10'
 keywords = []
 license = {file = 'LICENSE'}
 classifiers = [
-    'Development Status :: 5 - Production/Stable',
+    'Development Status :: 6 - Mature',
     'Intended Audience :: Developers',
     'Natural Language :: English',
-    'Operating System :: Unix',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.8',
-    'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',
     'Programming Language :: Python :: 3.13',
     'Programming Language :: Python :: 3.14',
+    'Programming Language :: Python :: 3.15',
     "Programming Language :: Python :: Implementation :: CPython",
     "License :: OSI Approved :: BSD License",
     "Operating System :: OS Independent",
-    "Development Status :: 6 - Mature",
     'Typing :: Typed'
 ]
-dependencies = ["typing-extensions>=4.5.0;python_version<'3.10'"]
+dependencies = ["typing-extensions>=4.5.0;python_version<'3.13'"]
 authors = [{'email' = 'ruud@channable.com'}]
 dynamic = ['version']
 


### PR DESCRIPTION
Noticed while bumping dependencies in an internal repository.

In `3.2.0` by accident we made `typing_extensions` a runtime dependency. This PR fixes this while also dropping versions that are end of life or almost are.
It should make `opnieuw` future proof for a year again :)